### PR TITLE
add ability to set min and max heapsize at runtime with env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV JIRA_VERSION  7.1.4
 # directory structure.
 RUN set -x \
     && apt-get update --quiet \
-    && apt-get install --quiet --yes --no-install-recommends libtcnative-1 xmlstarlet \
+    && apt-get install --quiet --yes --no-install-recommends ed libtcnative-1 xmlstarlet \
     && apt-get clean \
     && mkdir -p                "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_HOME}/caches/indexes" \
@@ -26,8 +26,10 @@ RUN set -x \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/logs" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/temp" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
+    && chown daemon:daemon     "${JIRA_INSTALL}/bin/setenv.sh" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
+    && touch -d "@0"           "${JIRA_INSTALL}/bin/setenv.sh" \
     && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
 
 # Use the default unprivileged account. This could be considered bad practice

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,4 +18,14 @@ if [ "$(stat --format "%Y" "${JIRA_INSTALL}/conf/server.xml")" -eq "0" ]; then
   fi
 fi
 
+# do the same for setenv.sh which sets heapsize among other things
+if [ "$(stat --format "%Y" "${JIRA_INSTALL}/bin/setenv.sh")" -eq "0" ]; then
+  if [ -n "${JIRA_MINIMUM_MEMORY}" ]; then
+    printf "%s\n" ",s/JVM_MINIMUM_MEMORY=.*/JVM_MINIMUM_MEMORY=\"${JIRA_MINIMUM_MEMORY}\"/" wq | ed -s "${JIRA_INSTALL}/bin/setenv.sh"
+  fi
+  if [ -n "${JIRA_MAXIMUM_MEMORY}" ]; then
+    printf "%s\n" ",s/JVM_MAXIMUM_MEMORY=.*/JVM_MAXIMUM_MEMORY=\"${JIRA_MAXIMUM_MEMORY}\"/" wq | ed -s "${JIRA_INSTALL}/bin/setenv.sh"
+  fi
+fi
+
 exec "$@"


### PR DESCRIPTION
This allows for setting min/max heapsize with JIRA_MINIMUM_MEMORY and JIRA_MAXIMUM_MEMORY environment variables. I had to use the arcane printf/ed stuff to avoid changing the ${JIRA_INSTALL}/bin directory to be owned by daemon user (sed must write a tempfile).