### PR TITLE
Correctly set the connector configuration if using an https reverse proxy

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,9 @@ if [ "$(stat --format "%Y" "${JIRA_INSTALL}/conf/server.xml")" -eq "0" ]; then
   if [ -n "${X_PROXY_SCHEME}" ]; then
     xmlstarlet ed --inplace --pf --ps --insert '//Connector[@port="8080"]' --type "attr" --name "scheme" --value "${X_PROXY_SCHEME}" "${JIRA_INSTALL}/conf/server.xml"
   fi
+  if [ "${X_PROXY_SCHEME}" -eq "https" ]; then
+    xmlstarlet ed --inplace --pf --ps --insert '//Connector[@port="8080"]' --type "attr" --name "secure" --value "true" "${JIRA_INSTALL}/conf/server.xml"
+  fi
   if [ -n "${X_PATH}" ]; then
     xmlstarlet ed --inplace --pf --ps --update '//Context/@path' --value "${X_PATH}" "${JIRA_INSTALL}/conf/server.xml"
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,7 @@ if [ "$(stat --format "%Y" "${JIRA_INSTALL}/conf/server.xml")" -eq "0" ]; then
   fi
   if [ "${X_PROXY_SCHEME}" -eq "https" ]; then
     xmlstarlet ed --inplace --pf --ps --insert '//Connector[@port="8080"]' --type "attr" --name "secure" --value "true" "${JIRA_INSTALL}/conf/server.xml"
+    xmlstarlet ed --inplace --pf --ps --insert '//Connector[@port="8080"]' --type "attr" --name "redirectPort" --value "${X_PROXY_PORT}" "${JIRA_INSTALL}/conf/server.xml"
   fi
   if [ -n "${X_PATH}" ]; then
     xmlstarlet ed --inplace --pf --ps --update '//Context/@path' --value "${X_PATH}" "${JIRA_INSTALL}/conf/server.xml"


### PR DESCRIPTION
Hello,

According to Atlassian's documentation, if we're using an https proxy, we should set secure=true and redirectPort to the same port as the proxy itself.

Here's a quick patch to handle this case correctly.