### PR TITLE
Add back libtcnative to improve performance.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV JIRA_VERSION  7.3.0
 # directory structure.
 RUN set -x \
     && apt-get update --quiet \
-    && apt-get install --quiet --yes --no-install-recommends xmlstarlet \
+    && apt-get install --quiet --yes --no-install-recommends -t jessie-backports xmlstarlet libtcnative-1 \
     && apt-get clean \
     && mkdir -p                "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_HOME}/caches/indexes" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV JIRA_VERSION  7.3.0
 # directory structure.
 RUN set -x \
     && apt-get update --quiet \
-    && apt-get install --quiet --yes --no-install-recommends -t jessie-backports xmlstarlet libtcnative-1 \
+    && apt-get install --quiet --yes --no-install-recommends xmlstarlet \
+    && apt-get install --quiet --yes --no-install-recommends -t jessie-backports libtcnative-1 \
     && apt-get clean \
     && mkdir -p                "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_HOME}/caches/indexes" \


### PR DESCRIPTION
Hello,

I added back the Tomcat Native library packages in the image to improve performance.

I had to use the backports one though because the main one is too old for the version of Tomcat JIRA ships with.

Also solves #30 and f910e86b505a8804f4d82ddd4525e47d4b9af774