### PR TITLE
Update to the non-deprecated Java base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 # Configuration variables.
 ENV JIRA_HOME     /var/atlassian/jira


### PR DESCRIPTION
I've not had a chance to test this yet, perhaps you can test this change together with the next Jira release?