### PR TITLE
Install ttf-dejavu font

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV JIRA_VERSION  7.8.0
 # Install Atlassian JIRA and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk add --no-cache curl xmlstarlet bash \
+    && apk add --no-cache curl xmlstarlet bash ttf-dejavu \
     && mkdir -p                "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_HOME}/caches/indexes" \
     && chmod -R 700            "${JIRA_HOME}" \


### PR DESCRIPTION
Various parts of JIRA need fonts to be installed, including graphs and
captchas. Without the fonts being installed, you recieve a NPE in
sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)

This commit adds the ttf-dejavu font

Resolves #65 and #66