### PR TITLE
Update Jira EAP download url to 8.0 EAP02

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
     && chmod -R 700            "${JIRA_HOME}" \
     && chown -R daemon:daemon  "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_INSTALL}/conf/Catalina" \
-    && curl -Ls                "http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.2.0-RC-20160629075822.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
+    && curl -Ls                "https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-8.0.0-EAP02.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
     && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz" | tar -xz --directory "${JIRA_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
     && chmod -R 700            "${JIRA_INSTALL}/conf" \
     && chmod -R 700            "${JIRA_INSTALL}/logs" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8
 # Configuration variables.
 ENV JIRA_HOME     /var/atlassian/jira
 ENV JIRA_INSTALL  /opt/atlassian/jira
-ENV JIRA_VERSION  7.2.0-RC01
+ENV JIRA_VERSION  8.0.0-EAP02
 
 # Install Atlassian JIRA and helper tools and setup initial home
 # directory structure.


### PR DESCRIPTION
I also added a .gitattributes file because i was working on a windows and it absolutely wrecked everything to have my global auto crlf force itself onto the files deployed into the container FS. Feel free to remove it if you see any issues. I just thought i'd be easier to enforce it at the repository level given it has functional impact on the windows dev experience specifically with the code in here.

Other than that it should be noted that, while i tested it and everything seems to work just like before... there currently seems to be no way to add Jira Service Desk or Jira Software via the application configuration inside jira (i assume they haven't released a compatible EAP for them).

Resolves #77 