### PR TITLE
Added support for specifying JVM_SUPPORT_RECOMMENDED_ARGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ EXPOSE 8080
 VOLUME ["${JIRA_HOME}", "/opt/atlassian/jira/logs"]
 
 # Set the default working directory as the installation directory.
-WORKDIR /opt/atlassian/jira
+WORKDIR /var/atlassian/jira
 
 COPY "docker-entrypoint.sh" "/"
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
I needed to have support for specifying the location of cacerts.
This allows that (same as with Atlassian's git and confluence Docker images).