### PR TITLE
OCI runtime create failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ VOLUME ["/var/atlassian/jira", "/opt/atlassian/jira/logs"]
 WORKDIR /var/atlassian/jira
 
 COPY "docker-entrypoint.sh" "/"
+USER root
+RUN chown daemon:daemon /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh
+USER daemon
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Run Atlassian JIRA as a foreground process by default.


### PR DESCRIPTION
Request to kindly review and see if this change can be merged.
This is to address the below error where Dockerfile and docker-entrypoint.sh are downloaded and image is built and run seperately. When docker image is built and run as separate steps, it throws the below error. 
This would be helpful when Dockerfile needs to be modified with additional steps. The command as per instructions to run the container (`docker run --detach --publish 8080:8080 cptactionhank/atlassian-jira:latest`) work just fine.
Included changes should work fine in both the cases.

Error:
`Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"/docker-entrypoint.sh\": permission denied": unknown.
`