### PR TITLE
Control the JVM memory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM openjdk:8-alpine
 ENV JIRA_HOME     /var/atlassian/jira
 ENV JIRA_INSTALL  /opt/atlassian/jira
 ENV JIRA_VERSION  8.20.2
+ENV JVM_MINIMUM_MEMORY 4096
+ENV JVM_MAXIMUM_MEMORY 8192
 
 # Install Atlassian JIRA and helper tools and setup initial home
 # directory structure.
@@ -28,7 +30,9 @@ RUN set -x \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
-    && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
+    && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml" \
+    && sed -i -Ee 's/^[\s#]*(JVM_MINIMUM_MEMORY[\s]*=).+$/\1"'${JVM_MINIMUM_MEMORY}'m"/' ${JIRA_INSTALL}/bin/setenv.sh \
+    && sed -i -Ee 's/^[\s#]*(JVM_MAXIMUM_MEMORY[\s]*=).+$/\1"'${JVM_MAXIMUM_MEMORY}'m"/' ${JIRA_INSTALL}/bin/setenv.sh
 
 # Use the default unprivileged account. This could be considered bad practice
 # on systems where multiple processes end up being executed by 'daemon' but


### PR DESCRIPTION
<!---
  Please read the CONTRIBUTING.md file before submitting a new pull request

  Note: Version bumping is performed automagically according to Atlassians own
  version feed by automation. If the version is behind of latest, please contact
  Atlassian about updating their feed to rectify this.
-->

*Issue #, NONE*

*Description of changes:*

The JVM memory needs to be set according to each server environment. I guess the default value is small for most of servers.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
