### PR TITLE
added a way to run the app instantly?

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ docker run --detach --publish 8080:8080 cptactionhank/atlassian-jira:latest
 
 Then simply navigate your preferred browser to `http://[dockerhost]:8080` and finish the configuration.
 
+Run without installation [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273430983350841344)
+
 ## Configuration
 
 You can configure a small set of things by supplying the following environment variables


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for this app, which help users to quickly run and try the app without installing and configuring the environment. Users don't need to pay for this service. Hope it can help you better promote the app. 

[![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273430983350841344)
Guidance: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：

Users click the badge Run in Cloud (teamcode demo).
Sign up first if they have not logged in.
After that, they will be directed to the Clone page and start to build & run this app.